### PR TITLE
Add response error processing

### DIFF
--- a/lib/nominatim.js
+++ b/lib/nominatim.js
@@ -1,3 +1,6 @@
+/*jslint node:true */
+/*jshint strict:false */
+/*jshint camelcase:false */
 var querystring = require('querystring'),
 	  request = require('request'),
     TQueue = require('tqueue');
@@ -15,13 +18,19 @@ var reverse_url = base_url + 'reverse?';
 
 function Nominatim() {
 
-};
+}
 
-queue.on('pop', function(item) {  
+queue.on('pop', function(item) {
   request(item.url + querystring.stringify(item.options), function(err, res) {
-    var results = JSON.parse(res.body);
+    var results
+    try {
+      results = JSON.parse(res.body);
+    } catch(error) {
+      err = new Error(res.body);
+      results = null;
+    }
 
-    item.callback(err, item.options, results);	
+    item.callback(err, item.options, results);
   });
 });
 
@@ -56,3 +65,5 @@ var extend = function(options) {
 };
 
 module.exports = Nominatim;
+
+console.log('Loading Nutanix Nominatim Fork')


### PR DESCRIPTION
The JSON.parse use to throw an unhandled error when nominatim
rate limited us.

@Harishgolla Please review this before you finish up the review of the cache-processing bug.
