### PR TITLE
Handling Error While Using Nominatim OpenstreetMap API

### DIFF
--- a/lib/nominatim.js
+++ b/lib/nominatim.js
@@ -22,12 +22,15 @@ function Nominatim() {
 
 queue.on('pop', function(item) {
   request(item.url + querystring.stringify(item.options), function(err, res) {
-    var results
-    try {
-      results = JSON.parse(res.body);
-    } catch(error) {
-      err = new Error(res.body);
-      results = null;
+    var results = [],
+        responseBody = res && res.body;
+
+    if (!err && responseBody) {
+      try {
+        results = JSON.parse(responseBody);
+      } catch (error) {
+        err = new Error('Expected Serialised JSON Response: ' + responseBody);
+      }
     }
 
     item.callback(err, item.options, results);


### PR DESCRIPTION
This commit is to handle error while using Nominatim OpenstreetMap API.

This module's functionality depends on the availability of 'http://nominatim.openstreetmap.org'. If the server is down or for some reason throws an error while using the API, the error scenario needs to be explicitly handled. This ensures other applications that are dependent on this module do not crash because of unhandled exceptions.

eg: Recently there were couple of instances when Watchtower crashed/restarted mainly due to this issue :

2017-05-03T13:04:41.034Z - info: module: sreDashboard.js: Uncaught Exception: TypeError: Cannot read property 'body' of undefined
    at Request._callback (/data/prod/watchtower/node_modules/nominatim/lib/nominatim.js:29:26)