### PR TITLE
Adding User Agent In The Request Header

### DIFF
--- a/lib/nominatim.js
+++ b/lib/nominatim.js
@@ -21,7 +21,14 @@ function Nominatim() {
 }
 
 queue.on('pop', function(item) {
-  request(item.url + querystring.stringify(item.options), function(err, res) {
+  var options = {
+    url: (item.url + querystring.stringify(item.options)),
+    headers: {
+      'User-Agent': 'Nominatim'
+    }
+  };
+
+  request(options, function(err, res) {
     var results = [],
         responseBody = res && res.body;
 


### PR DESCRIPTION
This commit is to fix 'Access Blocked' issue while hitting http://nominatim.openstreetmap.org/search API. Recently Nominatim seems to have updated terms of using the public API, one of which mandates adding User-Agent in the request header. Since Nominatim is hosted in our Github repo which internally makes search API calls, User-Agent is being set to 'Nominatim' itself.